### PR TITLE
Make the behavior of remove_changes_before match the description

### DIFF
--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -315,6 +315,8 @@ impl TopicCache {
   /// min_keep_samples.
   /// We must always keep below max_keep_samples.
   pub fn remove_changes_before(&mut self, remove_before: Timestamp) {
+    // TODO: Can we do better without being able to distinguish between instances?
+
     // Iterate backwards since the newer values are at the end.
     let mut keys = self.changes.keys().rev();
 

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -323,10 +323,11 @@ impl TopicCache {
     let split_key = match self.min_keep_samples {
       History::KeepAll => keys.nth(self.max_keep_samples as usize).copied(),
       History::KeepLast { depth } => {
+        let first_index = depth.min(self.max_keep_samples) as usize;
         let last_index = self.max_keep_samples.saturating_sub(depth) as usize;
 
         keys
-          .skip(depth as usize)
+          .skip(first_index)
           .enumerate()
           .find_map(|(index, &insertion_timestamp)| {
             (insertion_timestamp < remove_before || index >= last_index)

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -325,14 +325,14 @@ impl TopicCache {
     let split_key = match self.min_keep_samples {
       History::KeepAll => keys.nth(self.max_keep_samples as usize).copied(),
       History::KeepLast { depth } => {
-        let first_index = depth.min(self.max_keep_samples) as usize;
-        let last_index = self.max_keep_samples.saturating_sub(depth) as usize;
+        let min_keep_count = depth.min(self.max_keep_samples) as usize;
+        let last_sample_index = self.max_keep_samples.saturating_sub(depth) as usize;
 
         keys
-          .skip(first_index)
+          .skip(min_keep_count)
           .enumerate()
           .find_map(|(index, &insertion_timestamp)| {
-            (insertion_timestamp < remove_before || index >= last_index)
+            (insertion_timestamp < remove_before || index >= last_sample_index)
               .then_some(insertion_timestamp)
           })
       }


### PR DESCRIPTION
The current implementation of `remove_changes_before` has several problems:
- the `wrapping_sub` results in `min_remove_count` being close to `usize::MAX` in a lot of cases
- `self.changes.keys().take()` will iterate the start of the map, effectively discarding newer changes while keeping the older ones
- the documented property of keeping a maximum of `max_keep_samples` is not met
- (arguably less important than the rest) `self.changes.split_off` and `std::mem::replace` are always called, even if no changes should be discarded

This PR fixes the above issues while attempting to make the function easier to understand